### PR TITLE
Eliminated 'sticky' cursor keys when some text is already selected

### DIFF
--- a/app/ui/editor/editor.rb
+++ b/app/ui/editor/editor.rb
@@ -262,6 +262,8 @@ class HH::SideTabs::Editor
     def onkey(k)
       case k when :shift_home, :shift_end, :shift_up, :shift_left, :shift_down, :shift_right
         @t.marker = @t.cursor unless @t.marker
+      when :home, :end, :up, :left, :down, :right
+        @t.marker = nil
       end
 
       case k


### PR DESCRIPTION
Previously  after selecting some text with for example 'Shift-down' 
and then pressing just 'down' the following line was also selected 
instead of deselecting all the text.

Minor but quite annoying if you select some text, ctrl-x to cut it, and use the cursor keys to move to the intended insertion point (i.e. all the time).

Peace.
