### PR TITLE
Cache the 'last lesson' correctly, per lesson.

### DIFF
--- a/app/ui/tabs/lessons.rb
+++ b/app/ui/tabs/lessons.rb
@@ -32,7 +32,7 @@ class HH::SideTabs::Lessons < HH::SideTab
         value.each do |v|
           stack do
             britelink "icon-file.png", v[1] do
-              HH::APP.start_lessons name, v[2]
+              HH::APP.start_lessons v[1], v[2]
             end
           end
         end


### PR DESCRIPTION
Bug fix: create lessons with the lesson name, so caching the 'last lesson page' works correctly
