### PR TITLE
Bug fix save lesson page

### DIFF
--- a/app/ui/mainwindow.rb
+++ b/app/ui/mainwindow.rb
@@ -41,7 +41,7 @@ module HH::App
 
   def finalization
     # this method gets called on close
-    HH::LessonSet.close_lesson
+    HH::LessonSet.close_open_lesson
     gettab(:Editor).save_if_confirmed
 
     HH::PREFS['width'] = width


### PR DESCRIPTION
A fix for [Issue 51](https://github.com/hacketyhack/hacketyhack/issues/51) - the current lessons page isn't saved when HH closes.
