### PR TITLE
Replace the Lessons DSL with Markdown

### DIFF
--- a/app/ui/mainwindow.rb
+++ b/app/ui/mainwindow.rb
@@ -41,7 +41,7 @@ module HH::App
 
   def finalization
     # this method gets called on close
-    HH::LessonSet.close_lesson
+    HH::LessonSet.close_open_lesson
     gettab(:Editor).save_if_confirmed
 
     HH::PREFS['width'] = width


### PR DESCRIPTION
All the lessons are transcribed and massaged to a certain extent. I'm working on a lesson.md.example to include, too, to document what works & how, and to help people write other lessons.
