### PR TITLE
Don't force the title to a slug.

### DIFF
--- a/app/ui/editor/editor.rb
+++ b/app/ui/editor/editor.rb
@@ -235,7 +235,7 @@ class HH::SideTabs::Editor
             alert("To upload, first connect your account on hackety-hack.com by clicking Preferences near the bottom left of the window.")
           else
             hacker = Hacker.new :username => HH::PREFS['username'], :password => HH::PREFS['password']
-            hacker.save_program_to_the_cloud(script[:name].to_slug, @str) do |response|
+            hacker.save_program_to_the_cloud(script[:name], @str) do |response|
               if response.code == "200" || response.code == "302"
                 alert("Uploaded!")
               else


### PR DESCRIPTION
Currently any uploaded program will have the title set to a slug on the site. Instead let's have the site create the slug and keep the title the same as the program inside hacketyhack.

Agreed?
