### PR TITLE
Hacketyhack may now start without an internet connection

### DIFF
--- a/app/ui/tabs/home.rb
+++ b/app/ui/tabs/home.rb
@@ -15,8 +15,9 @@ class HH::SideTabs::Home < HH::SideTab
     super *args, &blk
     # never changes so is most efficient to load here
     @samples = HH.samples
-    Upgrade::check_latest_version do |version| if version['version'] != HH::VERSION
-        home_bulletin(version['version'])
+    if Web.internet_connection?
+      Upgrade::check_latest_version do |version| 
+        home_bulletin(version['version']) if version['version'] != HH::VERSION
       end
     end
   end

--- a/lib/web/web.rb
+++ b/lib/web/web.rb
@@ -9,6 +9,22 @@ module Web
   [JSON_MIME_TYPES, XML_MIME_TYPES].each do |ary|
     ary.map! { |str| /^#{Regexp::quote(str)}/ }
   end
+  
+  # checking for an internet connection to deactivate functionality, requiring
+  # an internet connection when there is no connection or the API is down
+  def self.check_internet_connection
+    begin
+      HH::API.get "" do |response| return response.kind_of? Net::HTTPOK end
+    rescue
+      return false
+    end
+  end
+  
+  # caching the result so we don't have to do a new request for each check
+  def self.internet_connection?
+    @connection ||= check_internet_connection
+  end
+  
 end
 
 module Hpricot


### PR DESCRIPTION
hacketyhack does not crash any more when starting without an Internet connection. The only place where I had to check for this was the check for the latest version. 

In order to determine whether we have a connection or not an HTTP request to the hacketyhack API is made in order to see whether the response is a HTTP Success.

I went with this approach rather than just rescuing the error, because the same function could be used to deactivate other Internet related functionality (Register a new account, Upload button of the editor).

This should close issue #140 (is there a way to get this pull request directly into this issue?)
