### PR TITLE
Change Gemfile source to 'https://rubygems.org' to remove warning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "cucumber"
 gem "hpricot"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     builder (3.0.0)
     cucumber (1.0.2)


### PR DESCRIPTION
Removes this warning when running `bundle install`: 

The source :rubygems is deprecated because HTTP requests are insecure.

Please change your source to 'https://rubygems.org' if possible, or
'http://rubygems.org' if not.
